### PR TITLE
Refactor read_private_data api

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,7 +36,7 @@ markers = [
     "read_private_data",
     "update_user",
     "delete_user",
-    "read_post",
+    "read_a_post",
     "read_posts",
     "create_post",
     "update_post",

--- a/backend/sns/posts/controller.py
+++ b/backend/sns/posts/controller.py
@@ -154,7 +154,7 @@ def unlike_post(
     response_model=schema.Post,
     status_code=status.HTTP_200_OK,
 )
-def read_post(
+def read_a_post(
     post_id: int,
     post_service: PostService = Depends(PostService),
     db: Session = Depends(db.get_db),
@@ -173,7 +173,7 @@ def read_post(
 
     - Post: post_id에 해당되는 글을 반환
     """
-    return post_service.read_post(db, post_id=post_id)
+    return post_service.read_a_post(db, post_id=post_id)
 
 
 @router.get(

--- a/backend/sns/posts/service.py
+++ b/backend/sns/posts/service.py
@@ -133,7 +133,7 @@ class PostService:
                 detail="글 삭제에 실패하였습니다.",
             )
 
-    def read_post(
+    def read_a_post(
         self,
         db: Session,
         post_id: int,

--- a/backend/sns/users/schema.py
+++ b/backend/sns/users/schema.py
@@ -41,13 +41,19 @@ class UserBase(Base):
     email: EmailStr
 
 
-class UserRead(UserBase):
-    email: EmailStr | None
+class UserPrivateRead(UserBase):
+    name: str
+    profile_text: str | None
+
+
+class UserRead(Base):
+    id: int
     name: str
     profile_text: str | None
 
 
 class UserUpdate(Base):
+    name: str | None
     profile_text: str | None
 
 

--- a/backend/sns/users/service.py
+++ b/backend/sns/users/service.py
@@ -857,20 +857,6 @@ class UserService:
                 detail="follow 관계 취소가 실패하였습니다.",
             )
 
-    def search_users(
-        self,
-        db: Session,
-        name: str,
-        page: int,
-    ) -> List[User]:
-        users_per_a_page = 10
-
-        user = user_crud.find_users(db, name, skip=page * users_per_a_page)
-
-        print(user)
-
-        return user
-
     def create_and_add_notification(
         self,
         db: Session,


### PR DESCRIPTION
<!--
pr 작성 전 한 번씩 읽어주세요.

# How to write Good Commit Message
#   1. Specify the type of commit: feat, enh, bugfix, style, docs
#   2. Separate the subject from the body with a blank line
#   3. Your commit message should not contain any whitespace errors
#   4. Remove unnecessary punctuation marks
#   5. Do not end the subject line with a period
#   6. Capitalize the subject line and each paragraph
#   7. Use the imperative mood in the subject line
#   8. Use the body to explain what changes you have made and why you made them.
#   9. Do not assume the reviewer understands what the original problem was, ensure you add it.
#   10. Do not think your code is self-explanatory
#   11. Follow the commit convention defined by your team
-->

## Changes?
<!-- 이 pr 로 인해서 무엇이 변경되었는지 작성해주세요 -->
1. 원래 있던 로그인한 유저의 프로필 정보를 읽는 api를 수정합니다.
- 로그인한 유저 외의 정보를 읽는 것과 서비스 로직이 동일하고, 반환되는 정보만 다르기 때문에 이를 schema로 차등을 두는 방식으로 수정했습니다.
- 로그인한 유저 외의 정보를 읽는 api: `/users/{user_id}`
- 로그인한 유저의 정보를 읽는 api: `/users/private-data`  
- 위 두 api의 반환값 차이는 email 밖에 없으나, 이 email로 로그인하고 패스워드 초기화를 진행하기 때문에 private data에 포함시켰었습니다.
  - 또한 현재 jwt에 email정보가 포함되어 있으므로 이 정보를 다른 정보로 대체할 예정입니다. 


2. User domain 의 service layer의 몇 몇 메서드의 반환값이 코드 일관성이 없어서 이 부분을 수정했습니다.  

3. 위 기능과 관련 없지만 큰 수정이라 판단되지 않아 함께 올렸습니다.

## Why we need?
<!-- 이 pr 이 왜 필요한지 작성해주세요 -->
- 코드 일관성과 코드 재사용성을 높이기 위해 수정했습니다.

## Test?
<!-- 어떻게 테스트했는지, 어떻게 reproduce 할 수 있는지 간단하게 작성해주세요 -->
- pytest로 테스트를 진행했습니다.

